### PR TITLE
Fix emoji and supplementary plane display

### DIFF
--- a/src/main/java/com/glitchcog/fontificator/bot/Message.java
+++ b/src/main/java/com/glitchcog/fontificator/bot/Message.java
@@ -397,10 +397,7 @@ public class Message
         {
             String timeStampStr = messageConfig.getTimerFormatter().format(timestamp);
             timeStampStr = applyCasing(timeStampStr, messageConfig.getMessageCasing());
-            for (int c = 0; c < timeStampStr.length(); c++)
-            {
-                keyList.add(new SpriteCharacterKey(timeStampStr.charAt(c)));
-            }
+            keyList.addAll(toSpriteArray(timeStampStr));
         }
 
         // Add badges to be placed right before the username
@@ -498,23 +495,14 @@ public class Message
         {
             if (messageConfig.showTimestamps())
             {
-                for (int c = 0; c < TIMESTAMP_USERNAME_SPACER.length(); c++)
-                {
-                    keyList.add(new SpriteCharacterKey(TIMESTAMP_USERNAME_SPACER.charAt(c)));
-                }
+                keyList.addAll(toSpriteArray(TIMESTAMP_USERNAME_SPACER));
             }
             String casedUsername = applyCasing(username, messageConfig.getMessageCasing());
-            for (int c = 0; c < casedUsername.length(); c++)
-            {
-                keyList.add(new SpriteCharacterKey(casedUsername.charAt(c)));
-            }
+            keyList.addAll(toSpriteArray(casedUsername));
         }
         if (messageConfig.showUsernames() || messageConfig.showTimestamps() || (emojiConfig.isAnyBadgesEnabled() && badges != null && !badges.isEmpty()))
         {
-            for (int c = 0; c < type.getContentBreaker().length(); c++)
-            {
-                keyList.add(new SpriteCharacterKey(type.getContentBreaker().charAt(c)));
-            }
+            keyList.addAll(toSpriteArray(type.getContentBreaker()));
         }
 
         // Parse out the emoji, if enabled
@@ -525,11 +513,7 @@ public class Message
         // Configured for no emoji, so just chars
         else
         {
-            String casedContent = applyCasing(content, messageConfig.getMessageCasing());
-            for (int c = 0; c < casedContent.length(); c++)
-            {
-                keyList.add(new SpriteCharacterKey(casedContent.charAt(c)));
-            }
+            keyList.addAll(toSpriteArray(applyCasing(content, messageConfig.getMessageCasing())));
         }
 
         // Return the list as an array, to be kept until configuration is modified requiring a reprocessing
@@ -625,14 +609,7 @@ public class Message
 
             if (emoji == null)
             {
-                String casedWord = applyCasing(words[w], casing);
-                // Done checking for all sorts of emoji types, so it's just a word. Set the characters.
-                for (int i = 0; i < casedWord.length(); )
-                {
-                    final int codepoint = casedWord.codePointAt(i);
-                    keyList.add(new SpriteCharacterKey(codepoint));
-                    i += Character.charCount(codepoint);
-                }
+                keyList.addAll(toSpriteArray(applyCasing(words[w], casing)));
             }
             else
             {
@@ -733,6 +710,28 @@ public class Message
         default:
             return str;
         }
+    }
+
+    /**
+     * Convert the string to a list of SpriteCharacterKeys by codepoint.
+     *
+     * @param str
+     * @returns A List of SpriteCharacterKeys
+     */
+    private static List<SpriteCharacterKey> toSpriteArray(String str)
+    {
+        // TODO java 1.8: We could use CharSequence and call codePoints method
+        List<SpriteCharacterKey> keyList = new ArrayList<SpriteCharacterKey>();
+
+        int i = 0;
+        while(i < str.length())
+        {
+            final int codepoint = str.codePointAt(i);
+            keyList.add(new SpriteCharacterKey(codepoint));
+            i += Character.charCount(codepoint);
+        }
+
+        return keyList;
     }
 
 }

--- a/src/main/java/com/glitchcog/fontificator/bot/Message.java
+++ b/src/main/java/com/glitchcog/fontificator/bot/Message.java
@@ -582,12 +582,12 @@ public class Message
 
         String[] words = content.split(SPACE_BOUNDARY_REGEX);
 
-        int charIndex = 0;
+        int codeIndex = 0;
 
         LazyLoadEmoji emoji = null;
         for (int w = 0; w < words.length; w++)
         {
-            EmoteAndIndices eai = emotes.get(charIndex);
+            EmoteAndIndices eai = emotes.get(codeIndex);
             if (eai != null && emojiConfig.isTwitchEnabled())
             {
                 // This catches subscriber emotes and any non-global emotes
@@ -627,9 +627,11 @@ public class Message
             {
                 String casedWord = applyCasing(words[w], casing);
                 // Done checking for all sorts of emoji types, so it's just a word. Set the characters.
-                for (int c = 0; c < casedWord.length(); c++)
+                for (int i = 0; i < casedWord.length(); )
                 {
-                    keyList.add(new SpriteCharacterKey(casedWord.charAt(c)));
+                    final int codepoint = casedWord.codePointAt(i);
+                    keyList.add(new SpriteCharacterKey(codepoint));
+                    i += Character.charCount(codepoint);
                 }
             }
             else
@@ -637,8 +639,9 @@ public class Message
                 keyList.add(new SpriteCharacterKey(emoji, false));
             }
 
-            // Increment the charIndex by the current word's length
-            charIndex += words[w].length();
+            // Increment the codeIndex by the current word's code point count
+            // Emoji indexes are in code points, but java is counting in fixed 16-bit units
+            codeIndex += words[w].codePointCount(0, words[w].length());
         }
     }
 

--- a/src/main/java/com/glitchcog/fontificator/sprite/SpriteCharacterKey.java
+++ b/src/main/java/com/glitchcog/fontificator/sprite/SpriteCharacterKey.java
@@ -14,7 +14,7 @@ public class SpriteCharacterKey
     /**
      * The character this represents
      */
-    private char character;
+    private int codepoint;
 
     /**
      * Whether the character falls outside of the inclusive ASCII range 32-127
@@ -47,6 +47,11 @@ public class SpriteCharacterKey
         this(character, null, false);
     }
 
+    public SpriteCharacterKey(int codepoint)
+    {
+        this(codepoint, null, false);
+    }
+
     /**
      * Construct as an emoji
      * 
@@ -54,33 +59,47 @@ public class SpriteCharacterKey
      */
     public SpriteCharacterKey(LazyLoadEmoji emoji, boolean badge)
     {
-        this((char) 127, emoji, badge);
+        this(127, emoji, badge);
     }
 
     /**
      * Private constructor to ensure that one or the other parameter is marked as unused
      * 
-     * @param character
+     * @param codepoint
      * @param emoji
      * @param badge
      *            Only used for emoji
      */
-    private SpriteCharacterKey(char character, LazyLoadEmoji emoji, boolean badge)
+    private SpriteCharacterKey(int codepoint, LazyLoadEmoji emoji, boolean badge)
     {
-        this.character = character;
-        this.extended = !SpriteFont.NORMAL_ASCII_KEY.contains(Character.toString(this.character));
+        this.codepoint = codepoint;
+        /* not-great: Take code point and toss surrogate pair, if present, to check if in ascii set */
+        this.extended = !SpriteFont.NORMAL_ASCII_KEY.contains(Character.toString(Character.toChars(this.codepoint)[0]));
         this.emoji = emoji;
         this.badge = badge;
     }
 
     /**
-     * Get the character, assuming this represents a character
+     * Get the character as a char, assuming this represents a character instead of emoji
      * 
      * @return char
      */
     public char getChar()
     {
-        return character;
+        // Not a pretty compromise.  Basically get the broken half a code point when trying to getChar() something that
+        // isn't in the BMP.  This is mostly OK.
+        // Ideally this would throw an exception if !Character.isBmpCodePoint(this.codepoint)
+        return Character.toChars(this.codepoint)[0];
+    }
+
+    /**
+     * Get the character as a codepoint, assuming this represents a character instead of emoji
+     *
+     * @return int
+     */
+    public int getCodepoint()
+    {
+        return this.codepoint;
     }
 
     /**
@@ -94,7 +113,7 @@ public class SpriteCharacterKey
     }
 
     /**
-     * Whether this sprite character is a char, not an emoji
+     * Whether this sprite character is a character, not an emoji
      * 
      * @return isChar
      */
@@ -104,7 +123,7 @@ public class SpriteCharacterKey
     }
 
     /**
-     * Whether this sprite character is an emoji, not a char
+     * Whether this sprite character is an emoji, not a character
      * 
      * @return isNotChar
      */
@@ -114,7 +133,7 @@ public class SpriteCharacterKey
     }
 
     /**
-     * Whether this sprite character is a badge emoji, not a char
+     * Whether this sprite character is a badge emoji, not a character
      * 
      * @return
      */
@@ -126,7 +145,7 @@ public class SpriteCharacterKey
     @Override
     public String toString()
     {
-        return isEmoji() ? "[E]" : Character.toString(getChar());
+        return isEmoji() ? "[E]" : new String(Character.toChars(this.codepoint));
     }
 
     /**

--- a/src/main/java/com/glitchcog/fontificator/sprite/SpriteFont.java
+++ b/src/main/java/com/glitchcog/fontificator/sprite/SpriteFont.java
@@ -128,8 +128,6 @@ public class SpriteFont
         return new int[] { (int) w, (int) h };
     }
 
-    private char[] fontMetricCharArray = new char[1];
-
     /**
      * Return how wide a character is in pixels- must take scale into consideration scale
      * 
@@ -148,7 +146,6 @@ public class SpriteFont
                 if (config.isExtendedCharEnabled())
                 {
                     // Return string width of extended char
-                    //fontMetricCharArray[0] = c.getChar();
                     baseWidth = fontMetrics.charWidth(c.getCodepoint());
                     // Don't include scale in this calculation, because it's already built into the font size
                     return (int) (baseWidth + config.getCharSpacing() * config.getFontScale());
@@ -163,7 +160,7 @@ public class SpriteFont
             else
             {
                 // Character
-                baseWidth = getCharacterBounds(c.getChar()).width;
+                baseWidth = getCharacterBounds(c.getCodepoint()).width;
             }
             return (int) ((baseWidth + config.getCharSpacing()) * config.getFontScale());
         }

--- a/src/main/java/com/glitchcog/fontificator/sprite/SpriteFont.java
+++ b/src/main/java/com/glitchcog/fontificator/sprite/SpriteFont.java
@@ -40,7 +40,7 @@ public class SpriteFont
 
     protected SpriteCache sprites;
 
-    protected Map<Character, Rectangle> characterBounds;
+    protected Map<Integer, Rectangle> characterBounds;
 
     /**
      * Characters that can be line breaks for wrapping to the next line
@@ -63,7 +63,7 @@ public class SpriteFont
     {
         logger.trace("Creating sprite font using config font filename " + (config == null ? "null" : config.getFontFilename()));
         this.config = config;
-        this.characterBounds = new HashMap<Character, Rectangle>();
+        this.characterBounds = new HashMap<Integer, Rectangle>();
         this.sprites = new SpriteCache(config);
     }
 
@@ -148,8 +148,8 @@ public class SpriteFont
                 if (config.isExtendedCharEnabled())
                 {
                     // Return string width of extended char
-                    fontMetricCharArray[0] = c.getChar();
-                    baseWidth = fontMetrics.charsWidth(fontMetricCharArray, 0, 1);
+                    //fontMetricCharArray[0] = c.getChar();
+                    baseWidth = fontMetrics.charWidth(c.getCodepoint());
                     // Don't include scale in this calculation, because it's already built into the font size
                     return (int) (baseWidth + config.getCharSpacing() * config.getFontScale());
                 }
@@ -213,7 +213,7 @@ public class SpriteFont
             Rectangle bounds = new Rectangle();
             bounds.setLocation(gridX * spriteWidth, gridY * spriteHeight);
             bounds.setSize(spriteWidth, spriteHeight);
-            characterBounds.put(c, bounds);
+            characterBounds.put((int)c, bounds);
         }
     }
 
@@ -294,13 +294,13 @@ public class SpriteFont
                 if (!leftEdgeFound)
                 {
                     // Then just use a quarter of the character width
-                    characterBounds.put(ckey, new Rectangle(x + charWidth / 4, y, charWidth / 2, charHeight));
+                    characterBounds.put((int)ckey, new Rectangle(x + charWidth / 4, y, charWidth / 2, charHeight));
                 }
                 // For all other characters, or for spaces that have some non transparent pixels, use the calculated
                 // bounds
                 else
                 {
-                    characterBounds.put(ckey, bounds);
+                    characterBounds.put((int)ckey, bounds);
                 }
 
                 letterIndex++;
@@ -314,9 +314,9 @@ public class SpriteFont
      * @param c
      * @return bounding box
      */
-    public Rectangle getCharacterBounds(char c)
+    public Rectangle getCharacterBounds(int c)
     {
-        if (!config.getCharacterKey().contains(Character.toString(c)))
+        if (!config.getCharacterKey().contains(new String(Character.toChars(c))))
         {
             c = config.getUnknownChar();
         }
@@ -595,7 +595,7 @@ public class SpriteFont
 
         if (sck.isChar())
         {
-            final boolean validNormalChar = !sck.isExtended() && characterBounds.containsKey(sck.getChar());
+            final boolean validNormalChar = !sck.isExtended() && characterBounds.containsKey(sck.getCodepoint());
             final boolean drawUnknownChar = !validNormalChar && !config.isExtendedCharEnabled();
 
             if (drawUnknownChar)
@@ -605,7 +605,7 @@ public class SpriteFont
 
             if (validNormalChar || drawUnknownChar)
             {
-                Rectangle bounds = characterBounds.get(sck.getChar());
+                Rectangle bounds = characterBounds.get(sck.getCodepoint());
                 sprites.getSprite(config).draw(g2d, drawX, drawY, bounds.width, bounds.height, bounds, config.getFontScale(), color);
                 if (debug)
                 {
@@ -617,7 +617,7 @@ public class SpriteFont
             else
             {
                 g2d.setColor(color);
-                g2d.drawString(Character.toString(sck.getChar()), drawX, drawY + (fontMetrics.getHeight() - fontMetrics.getDescent()) - config.getBaselineOffset() * config.getFontScale());
+                g2d.drawString(sck.toString(), drawX, drawY + (fontMetrics.getHeight() - fontMetrics.getDescent()) - config.getBaselineOffset() * config.getFontScale());
             }
         }
         else


### PR DESCRIPTION
A streamer I watch was getting corrupted output when they had "<twitchemote><unicode_emoji> 
<twitchemote>" in their chat, but it is actually just a unicode emoji and a twitch emote on the same line.
As an example, if ⚙️ were a twitch emote named "cog", then "⌨️ cog" would render as "￼￼ ️⚙️cog" 

First I wanted to just fix the counting so at least "⌨️ cog" would be "￼￼ ⚙️".  At least then the output would look OK, just with missing characters.
@growf and I looked at this and @growf contributed a lot of diagnosis.

This was the result of unicode emoji being outside the Basic Multilingual Plane.  Also had it happen with some esoteric CJK characters in testing.  Java treats them as two 'chars', a surrogate pair, which threw everything off.

This change's goal is to treat stuff as code points as often as possible to make it so we can track things in code point.  So this change draws emoji now too, but also acts better in general.

Testing is still ongoing to look for more edge cases, but so far this is looking pretty promising.

Commit message:
This fixes the display of unicode emoji and other code points living
outside the basic multilingual plane.

This is implemented by converting the Sprite Font and Characters to
mostly run on integer code points.
