### PR TITLE
Early support for current Twitch badges

### DIFF
--- a/src/main/java/com/glitchcog/fontificator/bot/ChatViewerBot.java
+++ b/src/main/java/com/glitchcog/fontificator/bot/ChatViewerBot.java
@@ -462,16 +462,13 @@ public class ChatViewerBot extends PircBot
                 log("Error parsing subscriber value \"" + turboStr + "\" in Twitch header");
             }
         }
-        privmsg.setPrime(paramMap.get("badges") != null && paramMap.get("badges").contains("premium"));
 
-        String userTypeStr = paramMap.get("user-type");
-        if (displayName != null && !displayName.trim().isEmpty() && displayName.equalsIgnoreCase(this.controlPanel.getChannelNoHash()))
+        if( paramMap.get("badges") != null )
         {
-            // Set the broadcaster badge based on the display name matching the channel connected to, since Twitch
-            // doesn't put this usertype into its IRC tags.
-            privmsg.setUserType(UserType.BROADCASTER);
+            privmsg.addBadges( paramMap.get("badges").split(",") );
         }
-        else if (userTypeStr != null && !userTypeStr.trim().isEmpty())
+        String userTypeStr = paramMap.get("user-type");
+        if (userTypeStr != null && !userTypeStr.trim().isEmpty())
         {
             // If the string value is something weird, the enum will just return NONE
             privmsg.setUserType(UserType.getByKey(userTypeStr));

--- a/src/main/java/com/glitchcog/fontificator/bot/TwitchPrivmsg.java
+++ b/src/main/java/com/glitchcog/fontificator/bot/TwitchPrivmsg.java
@@ -1,7 +1,9 @@
 package com.glitchcog.fontificator.bot;
 
 import java.awt.Color;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -32,6 +34,11 @@ public class TwitchPrivmsg
      * The list of emotes
      */
     private Map<Integer, EmoteAndIndices> emotes;
+
+    /**
+     * The list of badges
+     */
+    private ArrayList<String> badges;
 
     /**
      * Whether the user has a Twitch subscription to the channel to which the message is posted
@@ -85,6 +92,7 @@ public class TwitchPrivmsg
         postCount = 0;
         color = null;
         emotes = new HashMap<Integer, EmoteAndIndices>();
+        badges = new ArrayList<String>();
         turbo = false;
         prime = false;
         subscriber = false;
@@ -171,11 +179,19 @@ public class TwitchPrivmsg
     /**
      * Add to the list of emotes
      * 
-     * @param emoteSets
+     * @param emoteSet
      */
     public void addEmote(EmoteAndIndices emoteSet)
     {
         emotes.put(emoteSet.getBegin(), emoteSet);
+    }
+
+    public ArrayList<String> getBadges() {
+        return badges;
+    }
+
+    public void addBadges(String newbadges[]) {
+        this.badges.addAll( Arrays.asList(newbadges) );
     }
 
     /**

--- a/src/main/java/com/glitchcog/fontificator/bot/UserType.java
+++ b/src/main/java/com/glitchcog/fontificator/bot/UserType.java
@@ -2,18 +2,30 @@ package com.glitchcog.fontificator.bot;
 
 public enum UserType
 {
-    NONE(""), MOD("mod"), GLOBAL_MOD("global_mod"), ADMIN("admin"), STAFF("staff"), BROADCASTER("broadcaster");
+    NONE(""), MOD("mod", "moderator"), GLOBAL_MOD("global_mod"), ADMIN("admin"), STAFF("staff");
 
     private final String key;
+    private final String badge;
 
     private UserType(String key)
     {
+        this(key, key);
+    }
+
+    private UserType(String key, String badge)
+    {
         this.key = key;
+        this.badge = badge;
     }
 
     public String getKey()
     {
         return key;
+    }
+
+    public String getBadge()
+    {
+        return badge;
     }
 
     public static UserType getByKey(String key)

--- a/src/main/java/com/glitchcog/fontificator/config/ConfigEmoji.java
+++ b/src/main/java/com/glitchcog/fontificator/config/ConfigEmoji.java
@@ -109,6 +109,11 @@ public class ConfigEmoji extends Config
     private String twitchBadgesLoadedChannel;
 
     /**
+     * The loaded Twitch badges channel, or null if none is loaded
+     */
+    private String twitchBadgesLoadedGlobal;
+
+    /**
      * The loaded FrankerFaceZ badges channel, or null if none is loaded
      */
     private String ffzBadgesLoadedChannel;
@@ -404,6 +409,8 @@ public class ConfigEmoji extends Config
             //     return ControlPanelEmoji.TWITCH_EMOTE_VERSION.equals(type) && twitchEnabled != null && twitchEnabled && twitchLoaded != null && twitchLoaded;
             case TWITCH_BADGE:
                 return twitchBadgesEnabled != null && twitchBadgesEnabled && twitchBadgesLoadedChannel != null;
+            case TWITCH_BADGE_GLOBAL:
+                    return twitchBadgesEnabled != null && twitchBadgesEnabled && twitchBadgesLoadedGlobal != null;
             default:
                 // If it doesn't have a coded EmojiType, then we don't know it
                 return false;
@@ -506,6 +513,7 @@ public class ConfigEmoji extends Config
         result = prime * result + ((twitchEnabled == null) ? 0 : twitchEnabled.hashCode());
         result = prime * result + ((twitchLoaded == null) ? 0 : twitchLoaded.hashCode());
         result = prime * result + ((twitchBadgesLoadedChannel == null) ? 0 : twitchBadgesLoadedChannel.hashCode());
+        result = prime * result + ((twitchBadgesLoadedGlobal == null) ? 0 : twitchBadgesLoadedGlobal.hashCode());
         return result;
     }
 
@@ -712,7 +720,18 @@ public class ConfigEmoji extends Config
                 return false;
             }
         }
+        if (twitchBadgesLoadedGlobal == null)
+        {
+            if (other.twitchBadgesLoadedGlobal != null)
+            {
+                return false;
+            }
+        }
         else if (!twitchBadgesLoadedChannel.equals(other.twitchBadgesLoadedChannel))
+        {
+            return false;
+        }
+        else if (!twitchBadgesLoadedGlobal.equals(other.twitchBadgesLoadedGlobal))
         {
             return false;
         }
@@ -740,6 +759,7 @@ public class ConfigEmoji extends Config
         this.ffzEnabled = copy.ffzEnabled;
         this.twitchLoaded = copy.twitchLoaded;
         this.twitchBadgesLoadedChannel = copy.twitchBadgesLoadedChannel;
+        this.twitchBadgesLoadedChannel = copy.twitchBadgesLoadedGlobal;
         this.ffzLoadedChannel = copy.ffzLoadedChannel;
         this.ffzGlobalLoaded = copy.ffzGlobalLoaded;
         this.bttvEnabled = copy.bttvEnabled;
@@ -810,14 +830,25 @@ public class ConfigEmoji extends Config
     }
 
     /**
-     * Set whether the Twitch badges have been loaded
+     * Set whether the Twitch channel badges have been loaded
      * 
      * @param twitchBadgesLoadedChannel
-     *            from which the Twitch emotes are loaded
+     *            from which the Twitch channel badges are loaded
      */
-    public void setTwitchBadgesLoaded(String twitchBadgesLoadedChannel)
+    public void setTwitchBadgesLoadedChannel(String twitchBadgesLoadedChannel)
     {
         this.twitchBadgesLoadedChannel = twitchBadgesLoadedChannel;
+    }
+
+    /**
+     * Set whether the Twitch global badges have been loaded
+     *
+     * @param twitchBadgesLoadedGlobal
+     *            from which the Twitch global badges are loaded
+     */
+    public void setTwitchBadgesLoadedGlobal(String twitchBadgesLoadedGlobal)
+    {
+        this.twitchBadgesLoadedGlobal = twitchBadgesLoadedGlobal;
     }
 
     /**
@@ -960,6 +991,10 @@ public class ConfigEmoji extends Config
         {
             this.twitchBadgesLoadedChannel = job.getChannel();
         }
+        else if (EmojiType.TWITCH_BADGE_GLOBAL.equals(emojiType))
+        {
+            this.twitchBadgesLoadedGlobal = job.getChannel();
+        }
         else if (EmojiType.FRANKERFACEZ_BADGE.equals(emojiType))
         {
             this.ffzBadgesLoadedChannel = job.getChannel();
@@ -1022,6 +1057,7 @@ public class ConfigEmoji extends Config
         this.twitchLoaded = false;
         this.twitchCached = false;
         this.twitchBadgesLoadedChannel = null;
+        this.twitchBadgesLoadedGlobal = null;
         this.ffzBadgesLoadedChannel = null;
         this.ffzLoadedChannel = null;
         this.ffzGlobalLoaded = false;
@@ -1039,7 +1075,7 @@ public class ConfigEmoji extends Config
     public boolean isAnyWorkDone()
     {
         // @formatter:off
-        return twitchBadgesLoadedChannel != null || isTwitchLoaded() || isTwitchCached() || 
+        return twitchBadgesLoadedChannel != null || twitchBadgesLoadedGlobal != null || isTwitchLoaded() || isTwitchCached() ||
                ffzBadgesLoadedChannel != null || ffzLoadedChannel != null || isFfzGlobalLoaded() || isFfzCached() || 
                bttvLoadedChannel != null || isBttvGlobalLoaded() || isBttvCached();
         // @formatter:on

--- a/src/main/java/com/glitchcog/fontificator/config/ConfigEmoji.java
+++ b/src/main/java/com/glitchcog/fontificator/config/ConfigEmoji.java
@@ -812,7 +812,7 @@ public class ConfigEmoji extends Config
     /**
      * Set whether the Twitch badges have been loaded
      * 
-     * @param twitchLoadedChannel
+     * @param twitchBadgesLoadedChannel
      *            from which the Twitch emotes are loaded
      */
     public void setTwitchBadgesLoaded(String twitchBadgesLoadedChannel)
@@ -823,7 +823,7 @@ public class ConfigEmoji extends Config
     /**
      * Set whether the FrankerFaceZ badges have been loaded
      * 
-     * @param ffzLoadedChannel
+     * @param ffzBadgesLoadedChannel
      *            from which the FrankerFaceZ emotes are loaded
      */
     public void setFfzBadgesLoaded(String ffzBadgesLoadedChannel)

--- a/src/main/java/com/glitchcog/fontificator/emoji/EmojiJob.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/EmojiJob.java
@@ -18,17 +18,26 @@ public class EmojiJob
      */
     private final String channel;
 
+    /**
+     * Can be null if no channel ID is required
+     */
+    private final String channel_id;
+
     public EmojiJob(String oauth, EmojiType type, EmojiOperation op)
     {
-        this(oauth, type, op, null);
+        this(oauth, type, op, null, null);
     }
-
     public EmojiJob(String oauth, EmojiType type, EmojiOperation op, String channel)
+    {
+        this(oauth, type, op, channel, null);
+    }
+    public EmojiJob(String oauth, EmojiType type, EmojiOperation op, String channel, String channel_id)
     {
         this.type = type;
         this.op = op;
         this.oauth = oauth;
         this.channel = channel;
+        this.channel_id = channel_id;
     }
 
     public String getOauth()
@@ -51,12 +60,18 @@ public class EmojiJob
         return channel;
     }
 
+    public String getChannelId()
+    {
+        return channel_id;
+    }
+
     @Override
     public int hashCode()
     {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((channel == null) ? 0 : channel.hashCode());
+        result = prime * result + ((channel_id == null) ? 0 : channel_id.hashCode());
         result = prime * result + ((op == null) ? 0 : op.hashCode());
         result = prime * result + ((type == null) ? 0 : type.hashCode());
         return result;
@@ -78,6 +93,13 @@ public class EmojiJob
                 return false;
         }
         else if (!channel.equals(other.channel))
+            return false;
+        if (channel_id == null)
+        {
+            if (other.channel_id != null)
+                return false;
+        }
+        else if (!channel_id.equals(other.channel_id))
             return false;
         if (op != other.op)
             return false;

--- a/src/main/java/com/glitchcog/fontificator/emoji/EmojiType.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/EmojiType.java
@@ -8,20 +8,21 @@ package com.glitchcog.fontificator.emoji;
 public enum EmojiType
 {
     // @formatter:off
-    TWITCH_V1("Twitch Emotes from Chat V1", EmojiGroup.TWITCH, false, false),
+    TWITCH_V1("Twitch Emotes from Chat V1", EmojiGroup.TWITCH, false, false, true),
 
     /**
      * Twitch V2 API retired on February 14, 2017
      */
     @Deprecated 
-    TWITCH_V2("Twitch Emotes V2", EmojiGroup.TWITCH, false, false),
+    TWITCH_V2("Twitch Emotes V2", EmojiGroup.TWITCH, false, false, true),
     /**
      * Twitch V3 API retired on February 14, 2017
      */
     @Deprecated 
-    TWITCH_V3("Twitch Emotes V3", EmojiGroup.TWITCH, false, true),
+    TWITCH_V3("Twitch Emotes V3", EmojiGroup.TWITCH, false, true, true),
  
-    TWITCH_BADGE("Twitch Badge", EmojiGroup.TWITCH, true, false), 
+    TWITCH_BADGE("Twitch Badge", EmojiGroup.TWITCH, true, false),
+    TWITCH_BADGE_GLOBAL("Twitch Global Badge", EmojiGroup.TWITCH, true, false),
     FRANKERFACEZ_CHANNEL("FrankerFaceZ Emotes", EmojiGroup.FFZ, false, false), 
     FRANKERFACEZ_GLOBAL("FrankerFaceZ Global Emotes", EmojiGroup.FFZ, false, false), 
     FRANKERFACEZ_BADGE("FrankerFaceZ Badge", EmojiGroup.FFZ, true, false),
@@ -38,6 +39,8 @@ public enum EmojiType
 
     private final String description;
 
+    private final boolean canRegEx;
+
     /**
      * These are the types of emoji words to check against for manual messages.
      */
@@ -52,10 +55,16 @@ public enum EmojiType
 
     private EmojiType(String description, EmojiGroup group, boolean badge, boolean loadSetMap)
     {
+        this(description, group, badge, loadSetMap, false);
+    }
+
+    private EmojiType(String description, EmojiGroup group, boolean badge, boolean loadSetMap, boolean canRegEx)
+    {
         this.group = group;
         this.description = description;
         this.badge = badge;
         this.loadSetMap = loadSetMap;
+        this.canRegEx = canRegEx;
     }
 
     public boolean isTwitchEmote()
@@ -86,5 +95,10 @@ public enum EmojiType
     public String getDescription()
     {
         return description;
+    }
+
+    public boolean canRegEx()
+    {
+        return canRegEx;
     }
 }

--- a/src/main/java/com/glitchcog/fontificator/emoji/LazyLoadEmoji.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/LazyLoadEmoji.java
@@ -61,6 +61,8 @@ public class LazyLoadEmoji
 
     private boolean firstLoadFailureReported;
 
+    private String primaryidentifier;
+
     /**
      * Used for FFZ badges only
      */
@@ -70,23 +72,23 @@ public class LazyLoadEmoji
     {
         this(id, null, url, null, type);
     }
-
     public LazyLoadEmoji(String id, String replaces, String url, Color bgColor, EmojiType type) throws MalformedURLException
     {
-        this(id, replaces, url, DEFAULT_EMOJI_SIZE, DEFAULT_EMOJI_SIZE, bgColor, type);
+        this(id, replaces, url, DEFAULT_EMOJI_SIZE, DEFAULT_EMOJI_SIZE, bgColor, type, null);
     }
-
     public LazyLoadEmoji(String identifier, String url, int width, int height, EmojiType type) throws MalformedURLException
     {
-        this(identifier, url, width, height, null, type);
+        this(identifier, url, width, height, null, type, null);
     }
-
-    public LazyLoadEmoji(String identifier, String url, int width, int height, Color bgColor, EmojiType type) throws MalformedURLException
+    public LazyLoadEmoji(String identifier, String url, int width, int height, EmojiType type, String primaryidentifier) throws MalformedURLException
     {
-        this(identifier, null, url, width, height, bgColor, type);
+        this(identifier, url, width, height, null, type, primaryidentifier);
     }
-
-    public LazyLoadEmoji(String identifier, String replaces, String url, int width, int height, Color bgColor, EmojiType type) throws MalformedURLException
+    public LazyLoadEmoji(String identifier, String url, int width, int height, Color bgColor, EmojiType type, String primaryidentifier) throws MalformedURLException
+    {
+        this(identifier, null, url, width, height, bgColor, type, primaryidentifier);
+    }
+    public LazyLoadEmoji(String identifier, String replaces, String url, int width, int height, Color bgColor, EmojiType type, String primaryidentifier) throws MalformedURLException
     {
         this.identifier = identifier;
         this.replaces = replaces;
@@ -96,6 +98,7 @@ public class LazyLoadEmoji
         this.height = height;
         this.firstLoadFailureReported = false;
         this.bgColor = bgColor;
+        this.primaryidentifier = primaryidentifier == null ? identifier : primaryidentifier;
     }
 
     public void cacheImage()
@@ -265,4 +268,7 @@ public class LazyLoadEmoji
         return replaces;
     }
 
+    public String getPrimaryidentifier() {
+        return primaryidentifier;
+    }
 }

--- a/src/main/java/com/glitchcog/fontificator/emoji/loader/EmojiApiLoader.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/loader/EmojiApiLoader.java
@@ -23,6 +23,8 @@ public class EmojiApiLoader
 
     private static final String CHANNEL_NAME_REPLACE = "%CHANNEL_NAME%";
 
+    private static final String ID_REPLACE = "%ID_NUMBER%";
+
     public static final String OAUTH_REPLACE = "%OAUTH%";
 
     public static final String EMOTE_ID_REPLACE = "%EMOTE_ID%";
@@ -51,6 +53,16 @@ public class EmojiApiLoader
      * The base URL for getting the channel specific Twitch badges from the API
      */
     private static final String TWITCH_URL_BADGES = "https://api.twitch.tv/kraken/chat/" + CHANNEL_NAME_REPLACE + "/badges" + OAUTH_REPLACE;
+
+    /**
+     * The base URL for getting the channel specific Twitch badges from the new API
+     */
+    private static final String TWITCH_URL_BADGES2 = "https://badges.twitch.tv/v1/badges/channels/"+ ID_REPLACE + "/display" + OAUTH_REPLACE;
+
+    /**
+     * The base URL for getting the channel specific Twitch badges from the new API
+     */
+    private static final String TWITCH_URL_BADGES_GLOBAL = "https://badges.twitch.tv/v1/badges/global/display" + OAUTH_REPLACE;
 
     /**
      * The URL for getting the global FrankerFaceZ emotes from the API
@@ -146,15 +158,20 @@ public class EmojiApiLoader
         this.url = url;
     }
 
-    public void prepLoad(EmojiType emojiType, String channel, String oauth)
+    public void prepLoad(EmojiType emojiType, String channel, String oauth, String id)
     {
         // FrankerFaceZ API requires the channel name to be all lowercase, Twitch V2 is case agnostic
         channel = channel == null ? null : channel.toLowerCase();
-        String chanUrl = getUrl(emojiType, channel, oauth);
+        String chanUrl = getUrl(emojiType, channel, oauth, id);
         prepLoad(chanUrl);
     }
 
-    private String getUrl(EmojiType emojiType, String channel, String oauth)
+    public void prepLoad(EmojiType emojiType, String channel, String oauth)
+    {
+        this.prepLoad(emojiType, channel, oauth, null);
+    }
+
+    private String getUrl(EmojiType emojiType, String channel, String oauth, String id)
     {
         final String oauthLabel = "oauth:";
         if (oauth.contains(oauthLabel))
@@ -179,12 +196,31 @@ public class EmojiApiLoader
         // case TWITCH_V3:
         //     return TWITCH_URL_V3;
         case TWITCH_BADGE:
-            return TWITCH_URL_BADGES.replaceAll(CHANNEL_NAME_REPLACE, channel).replaceAll(OAUTH_REPLACE, oauth);
+            if (id != null)
+            {
+                return TWITCH_URL_BADGES2.replaceAll(ID_REPLACE, id).replaceAll(OAUTH_REPLACE, oauth);
+            }
+            else
+            {
+                return TWITCH_URL_BADGES.replaceAll(CHANNEL_NAME_REPLACE, channel).replaceAll(OAUTH_REPLACE, oauth);
+            }
+        case TWITCH_BADGE_GLOBAL:
+                if (id != null)
+                {
+                    return TWITCH_URL_BADGES_GLOBAL.replaceAll(ID_REPLACE, id).replaceAll(OAUTH_REPLACE, oauth);
+                }
+                else
+                {
+                    return null;
+                }
         default:
             return null;
         }
     }
-
+    private String getUrl(EmojiType emojiType, String channel, String oauth)
+    {
+        return this.getUrl(emojiType, channel, oauth, null);
+    }
     public boolean initLoad() throws IOException, MalformedURLException, FileNotFoundException
     {
         if (this.url != null)

--- a/src/main/java/com/glitchcog/fontificator/emoji/loader/EmojiParser.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/loader/EmojiParser.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.google.gson.*;
 import org.apache.log4j.Logger;
 
 import com.glitchcog.fontificator.bot.UserType;
@@ -23,15 +24,11 @@ import com.glitchcog.fontificator.emoji.loader.frankerfacez.FfzBadgesAndUsers;
 import com.glitchcog.fontificator.emoji.loader.frankerfacez.FfzEmote;
 import com.glitchcog.fontificator.emoji.loader.frankerfacez.Room;
 import com.glitchcog.fontificator.emoji.loader.twitch.TwitchBadges;
+import com.glitchcog.fontificator.emoji.loader.twitch.TwitchBadgesNew;
 import com.glitchcog.fontificator.emoji.loader.twitch.TwitchEmoteV2;
 import com.glitchcog.fontificator.emoji.loader.twitch.TwitchEmoteV3;
 import com.glitchcog.fontificator.emoji.loader.twitch.TwitchIdSetLink;
 import com.glitchcog.fontificator.gui.controls.panel.LogBox;
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 
 /**
@@ -63,7 +60,7 @@ public class EmojiParser
      *            the type of the emoji
      * @param jsonData
      *            the JSON data of the emoji to parse
-     * @param mapData
+     * @param jsonMapData
      *            can be null for non-Twitch emoji
      * @throws IOException
      */
@@ -86,6 +83,7 @@ public class EmojiParser
         //     parseTwitchEmoteJsonV3(manager, jsonData, jsonMapData);
         //     break;
         case TWITCH_BADGE:
+        case TWITCH_BADGE_GLOBAL:
             parseTwitchBadges(emojiMap, jsonData);
             break;
         case BETTER_TTV_CHANNEL:
@@ -224,24 +222,70 @@ public class EmojiParser
     {
         JsonElement jsonElement = new JsonParser().parse(jsonData);
 
+        Boolean isNewStyle = jsonElement.getAsJsonObject().has("badge_sets");
+
         Gson gson = new Gson();
-
-        Type emoteType = new TypeToken<Map<String, TwitchBadges>>()
-        {
-        }.getType();
-        Map<String, TwitchBadges> jsonMap = gson.fromJson(jsonElement, emoteType);
-
         int badgeCount = 0;
-        for (Entry<String, TwitchBadges> badge : jsonMap.entrySet())
+
+        if (!isNewStyle)
         {
-            if (badge.getValue() != null && badge.getValue().getImage() != null)
-            {
-                badgeCount++;
-                LazyLoadEmoji llBadge = new LazyLoadEmoji(badge.getKey(), badge.getValue().getImage(), TWITCH_BADGE_PIXEL_SIZE, TWITCH_BADGE_PIXEL_SIZE, EmojiType.TWITCH_BADGE);
-                badgeMap.put(badge.getKey(), llBadge);
+            Type emoteType = new TypeToken<Map<String, TwitchBadges>>() {
+            }.getType();
+            Map<String, TwitchBadges> jsonMap = gson.fromJson(jsonElement, emoteType);
+
+            for (Entry<String, TwitchBadges> badge : jsonMap.entrySet()) {
+                if (badge.getValue() != null && badge.getValue().getImage() != null) {
+                    badgeCount++;
+                    LazyLoadEmoji llBadge = new LazyLoadEmoji(badge.getKey(), badge.getValue().getImage(), TWITCH_BADGE_PIXEL_SIZE, TWITCH_BADGE_PIXEL_SIZE, EmojiType.TWITCH_BADGE);
+                    badgeMap.put(badge.getKey(), llBadge);
+                }
             }
         }
+        else
+        {
+            JsonElement badge_sets = jsonElement.getAsJsonObject().get("badge_sets");
+            JsonObject badge_sets_object = badge_sets.isJsonObject() ? badge_sets.getAsJsonObject() : new JsonObject();
 
+            for (Map.Entry<String,JsonElement> entry : badge_sets_object.entrySet())
+            {
+                String unversioned_key = entry.getKey();
+                JsonElement badge_set_element = entry.getValue();
+                if (!badge_set_element.isJsonObject() || !badge_set_element.getAsJsonObject().has("versions"))
+                {
+                    // TODO: Error message?
+                    continue;
+                }
+                JsonElement versions_element = badge_set_element.getAsJsonObject().get("versions");
+                if (!versions_element.isJsonObject())
+                {
+                    // TODO: Error message?
+                    continue;
+                }
+                Type emoteType = new TypeToken<Map<String, TwitchBadgesNew>>() {
+                }.getType();
+                Map<String, TwitchBadgesNew> jsonMap;
+                try {
+                    jsonMap = gson.fromJson(versions_element, emoteType);
+                }
+                catch( JsonSyntaxException e ) {
+                    // TODO: Error message?
+                    continue;
+                }
+
+                for (Entry<String, TwitchBadgesNew> sub_badge : jsonMap.entrySet()) {
+                    // The unversioned key is something like "subscriber".
+                    // The sub_badge is something like "1" or "6".
+                    // In the specific case of subscriber badges, "subscriber/1" is a 1 month badge and
+                    //  "subscriber/6" is a 6 month badge
+                    if (sub_badge.getValue() != null && sub_badge.getValue().getImage_url_1x() != null) {
+                        String badge_key = unversioned_key + "/" + sub_badge.getKey();
+                        LazyLoadEmoji llBadge = new LazyLoadEmoji(badge_key, sub_badge.getValue().getImage_url_1x(), TWITCH_BADGE_PIXEL_SIZE, TWITCH_BADGE_PIXEL_SIZE, EmojiType.TWITCH_BADGE, unversioned_key);
+                        badgeMap.put(badge_key, llBadge);
+                        badgeCount++;
+                    }
+                }
+            }
+        }
         logBox.log(badgeCount + " Twitch badge" + (badgeCount == 1 ? "" : "s") + " loaded");
     }
 
@@ -258,7 +302,7 @@ public class EmojiParser
 
         for (Badge b : badgesAndUsers.getBadges())
         {
-            manager.getEmojiByType(EmojiType.FRANKERFACEZ_BADGE).put("" + b.getId(), new LazyLoadEmoji(b.getName(), "moderator".equals(b.getReplaces()) ? UserType.MOD.getKey() : b.getReplaces(), "http:" + b.getImage(), b.getColorParsed(), EmojiType.FRANKERFACEZ_BADGE));
+            manager.getEmojiByType(EmojiType.FRANKERFACEZ_BADGE).put("" + b.getId(), new LazyLoadEmoji(b.getName(), b.getReplaces(), "http:" + b.getImage(), b.getColorParsed(), EmojiType.FRANKERFACEZ_BADGE));
         }
 
         manager.setFfzBadgeUsers(badgesAndUsers.getUsers());

--- a/src/main/java/com/glitchcog/fontificator/emoji/loader/EmojiParser.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/loader/EmojiParser.java
@@ -328,7 +328,7 @@ public class EmojiParser
         final boolean customFfzModBadgeExists = room != null && room.getModerator_badge() != null;
         if (customFfzModBadgeExists)
         {
-            LazyLoadEmoji modLle = new LazyLoadEmoji(UserType.MOD.getKey(), UserType.MOD.getKey(), "https:" + room.getModerator_badge(), ConfigEmoji.MOD_BADGE_COLOR, EmojiType.FRANKERFACEZ_BADGE);
+            LazyLoadEmoji modLle = new LazyLoadEmoji(UserType.MOD.getBadge(), UserType.MOD.getBadge(), "https:" + room.getModerator_badge(), ConfigEmoji.MOD_BADGE_COLOR, EmojiType.FRANKERFACEZ_BADGE);
             manager.getEmojiByType(EmojiType.FRANKERFACEZ_BADGE).put(UserType.MOD.getKey(), modLle);
             logBox.log("Loaded the custom FrankerFaceZ moderator badge");
         }

--- a/src/main/java/com/glitchcog/fontificator/emoji/loader/twitch/TwitchBadgesNew.java
+++ b/src/main/java/com/glitchcog/fontificator/emoji/loader/twitch/TwitchBadgesNew.java
@@ -1,0 +1,77 @@
+
+        package com.glitchcog.fontificator.emoji.loader.twitch;
+
+
+public class TwitchBadgesNew {
+
+    private String image_url_1x;
+    private String image_url_2x;
+    private String image_url_4x;
+    private String description;
+    private String title;
+
+    /**
+     * No args constructor for use in serialization
+     *
+     */
+    public TwitchBadgesNew() {
+    }
+
+    /**
+     *
+     * @param image_url_2x
+     * @param title
+     * @param description
+     * @param image_url_4x
+     * @param image_url_1x
+     */
+    public TwitchBadgesNew(String image_url_1x, String image_url_2x, String image_url_4x, String description, String title) {
+        super();
+        this.image_url_1x = image_url_1x;
+        this.image_url_2x = image_url_2x;
+        this.image_url_4x = image_url_4x;
+        this.description = description;
+        this.title = title;
+    }
+
+    public String getImage_url_1x() {
+        return image_url_1x;
+    }
+
+    public void setImage_url_1x(String image_url_1x) {
+        this.image_url_1x = image_url_1x;
+    }
+
+    public String getImage_url_2x() {
+        return image_url_2x;
+    }
+
+    public void setImage_url_2x(String image_url_2x) {
+        this.image_url_2x = image_url_2x;
+    }
+
+    public String getImage_url_4x() {
+        return image_url_4x;
+    }
+
+    public void setImage_url_4x(String image_url_4x) {
+        this.image_url_4x = image_url_4x;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+}

--- a/src/main/java/com/glitchcog/fontificator/gui/controls/panel/ControlPanelEmoji.java
+++ b/src/main/java/com/glitchcog/fontificator/gui/controls/panel/ControlPanelEmoji.java
@@ -389,6 +389,20 @@ public class ControlPanelEmoji extends ControlPanelBase
                         }
                     }
 
+                    if (clickTwitchBadges && !config.isTwitchBadgesLoaded(getConnectChannel()))
+                    {
+                        EmojiJob job = new EmojiJob(oauth, EmojiType.TWITCH_BADGE_GLOBAL, EmojiOperation.LOAD, getConnectChannel());
+                        // No check for enable all here, because badges are independent of the emoji enableAll toggle
+                        if (enableTwitchBadges.isSelected())
+                        {
+                            jobsToRun.add(job);
+                        }
+                        else
+                        {
+                            jobsToCancel.add(job);
+                        }
+                    }
+
                     if (clickFfzBadges && !config.isFfzBadgesLoaded(getConnectChannel()))
                     {
                         EmojiJob job = new EmojiJob(oauth, EmojiType.FRANKERFACEZ_BADGE, EmojiOperation.LOAD, getConnectChannel());
@@ -720,6 +734,14 @@ public class ControlPanelEmoji extends ControlPanelBase
             if (channel == null)
             {
                 ChatWindow.popup.handleProblem("Please specify a channel on the Connection tab to load badges");
+                jobs.clear();
+                return jobs;
+            }
+            jobs.add(new EmojiJob(oauth, EmojiType.TWITCH_BADGE_GLOBAL, EmojiOperation.LOAD, channel, null)); /* TODO: Need ID somehow */
+            if (channel == null)
+            {
+                /* TODO: Error message not good enough */
+                ChatWindow.popup.handleProblem("Please specify a channel ID on the Connection tab to load badges");
                 jobs.clear();
                 return jobs;
             }

--- a/src/main/java/com/glitchcog/fontificator/gui/emoji/EmojiWorker.java
+++ b/src/main/java/com/glitchcog/fontificator/gui/emoji/EmojiWorker.java
@@ -152,9 +152,7 @@ public class EmojiWorker extends SwingWorker<Integer, EmojiWorkerReport>
      * 
      * @param manager
      * @param progressPanel
-     * @param channel
-     * @param emojiType
-     * @param opType
+     * @param job
      * @param logBox
      * @param initialReport
      */

--- a/src/main/java/com/glitchcog/fontificator/gui/emoji/EmojiWorker.java
+++ b/src/main/java/com/glitchcog/fontificator/gui/emoji/EmojiWorker.java
@@ -187,6 +187,7 @@ public class EmojiWorker extends SwingWorker<Integer, EmojiWorkerReport>
             final EmojiType emojiType = job.getType();
             final String channel = job.getChannel();
             final String oauth = job.getOauth();
+            final String channel_id = job.getChannelId();
 
             if (EmojiOperation.LOAD == opType)
             {
@@ -199,7 +200,7 @@ public class EmojiWorker extends SwingWorker<Integer, EmojiWorkerReport>
                 }
 
                 // The proper load for the emoji
-                loader.prepLoad(emojiType, channel, oauth);
+                loader.prepLoad(emojiType, channel, oauth, channel_id);
                 String data = runLoader(emojiType);
                 if (data != null)
                 {
@@ -218,7 +219,7 @@ public class EmojiWorker extends SwingWorker<Integer, EmojiWorkerReport>
                 if (emojiType == EmojiType.TWITCH_BADGE)
                 {
                     TypedEmojiMap tbMap = manager.getEmojiByType(EmojiType.TWITCH_BADGE);
-                    tbMap.put("prime", new LazyLoadEmoji("prime", TWITCH_BADGE_PRIME, EmojiType.TWITCH_BADGE));
+                    //tbMap.put("prime", new LazyLoadEmoji("prime", TWITCH_BADGE_PRIME, EmojiType.TWITCH_BADGE));
                 }
 
                 Thread.sleep(1L);


### PR DESCRIPTION
Here's the first phase of changes for new badge support.

I'm very very open to criticism and corrections on this.  I'll admit java is not a language I've touched much in recent years.  I'm quite flexible.  My end goal with all of this was to get it so that I'd see current subscriber emotes in the widget and the rest flowed from that.

What is critically missing from this is a way to retrieve channel/user IDs.
There's multiple ways.: IRC broadcasts the room ID to you once you join.  There's an
HTTP REST API from Twitch to look up a user ID from a username.
How that is handled in relationship to the ability to preload emotes/badges and/or to interject this loading into the connection process was a problem I did not solve.
Perhaps that can be solved by glitchcog in another patch on this issue-11 branch.  Without that, I don't think it should merge into master.  I probably broke classic badges with this patchset.

Additionally, since I'm mostly improving this for a twitch broadcaster named "pjdicesare", I got
some feedback from them. One thing that came up is that once support for all these badges are
added, it could become quite too much and all the extra badges would take away from screen space
in the widget. With up to 4 twitch badges now possible at once, that might turn out to be too much at once.  But having an up to date subscriber emote seemed useful, which again is why I started working on this in the first place.


Info about new badges and a bit about the implementation:
-------
New Twitch badges are based on being part of the IRC v3 message tags

Examples:
badges=subscriber/1,moderator/1
badges=subscriber/6,bits/1000
badges=prime/1

https://dev.twitch.tv/docs/v5/guides/irc/
Section "PRIVMSG (Twitch Tags)" documents the badges tag.

The twitch badges are described by a different json format from what used to be and are available here:
https://badges.twitch.tv/v1/badges/channels/_ID_/display

The global badges are here: https://badges.twitch.tv/v1/badges/global/display

In order to handle this, plus the interaction with FFZ's badge overrides, I had to change several things.
You'll note that I've tried to identify badges by their "primary identifier", which isn't a name I'm married to, either.
A primary identifier for "subscriber/6" is "subscriber".  A primary identifier for "moderator/1" is "moderator". Coincidentally, this makes it
possible to figure out which FFZ badge overrides the "moderator" identifier.